### PR TITLE
fix: confirm example should use confirm function

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import {confirm} from 'react-bootstrap-confirmation';
 
 const ConfirmButton = () => {
   const display = async () => {
-    const result = await alert('Are you really sure?');
+    const result = await confirm('Are you really sure?');
     console.log('True if confirmed, false otherwise:', result);
   };
   return (


### PR DESCRIPTION
The confirm example was using the alert() function rather than the confirm() function. 
This PR fixes that typo/copy paste error.