### PR TITLE
Add support for mounting modals elsewhere

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,9 @@ Confirmation.defaultProps = {
   dismiss: undefined,
 };
 
-const confirmLow = createConfirmation(confirmable(Confirmation));
+export const confirm = (message, options = {}, mountingNode = null) => {
+  const confirmLow = createConfirmation(confirmable(Confirmation), 1000, mountingNode);
 
-export const confirm = (message, options = {}) => {
   return confirmLow(Object.assign({confirmation: message}, options));
 };
 
@@ -128,8 +128,9 @@ Alert.defaultProps = {
   dismiss: undefined,
 };
 
-const alertLow = createConfirmation(confirmable(Alert));
 
-export const alert = (message, options = {}) => {
+export const alert = (message, options = {}, mountingNode = null) => {
+  const alertLow = createConfirmation(confirmable(Alert), 1000, mountingNode);
+
   return alertLow(Object.assign({confirmation: message}, options));
 };


### PR DESCRIPTION
Closes #23 

Not 100% sure if I got the syntax right, but looking at the source of `createConfirmation` it should be alright[^1]!

The `mountingNode` parameter could be merged into `options`, although all of the other `options` are attributes of the `<Confirmation>` component and its children, so that feels a bit out of place.

[^1]: https://github.com/haradakunihiko/react-confirm/blob/3f6a23c353338f7e0302b6e6c5e53c8d46c3e899/src/createConfirmation.js#L4